### PR TITLE
Add reference: Villarreal et al. 2020

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Icons refer to the following:
 multi-task model was able to correctly predict the majority label.
 * Jiang & de Marneffe, 2022. [Investigating Reasons for Disagreement in Natural Language Inference](https://github.com/njjiang/NLI_disagreement_taxonomy). TACL. Provides a novel linguistic taxonomy to characterize disagreements in natural language inference datasets.
 * :small_orange_diamond: Wan et al., 2023. [Everyone’s Voice Matters: Quantifying Annotation Disagreement Using Demographic Information](https://github.com/minnesotanlp/Quantifying-Annotation-Disagreement). AAAI. Predict human label variation on five subjective tasks, examine demographic information.  
+* Villarreal et al., 2020. [From categories to gradience: Auto-coding sociophonetic variation with random forests](https://www.journal-labphon.org/article/id/6264/). Demonstrates a use case where probabilistic predictions trained on binary 'ground truth' correlated with annotator uncertainty.
 
 This list above are selected key references. Please see our EMNLP 2022 theme paper (Plank, 2022) for further references related to annotator culture/backgrounds, different terms proposed in the literature and more. If you know of relevant related work (not datasets), please leave an Issue. For more datasets, please see contributing.md
 


### PR DESCRIPTION
Not sure if this fits in here, but our 2020 article aimed at a phonetician/variationist audience seems in the same spirit---especially [section 5](https://www.journal-labphon.org/article/id/6264/#heading4), which argues that annotator disagreement is a feature, not a bug.